### PR TITLE
Fixed wrong assert in evaluation.py

### DIFF
--- a/src/hpt/evaluation.py
+++ b/src/hpt/evaluation.py
@@ -62,7 +62,8 @@ def evaluate_performance(y_true: np.ndarray, y_pred: np.ndarray) -> dict:
 
     # True Negative Rate
     results["tnr"] = safe_division(tn, label_neg)
-    assert results["tnr"] + results["fpr"] == 1
+    if results["tnr"] + results["fpr"] != 0:
+        assert results["tnr"] + results["fpr"] == 1
 
     # Precision
     results["precision"] = safe_division(tp, pred_pos)


### PR DESCRIPTION
The previous code would throw an error if `results["tnr"] + results["fpr"] = 0`.

This can happen if for a sensitive attribute a class has only a few values, and then both `tnr` and `fpr` are 0.